### PR TITLE
Refactor content and store modules by removing `create_image_file` function

### DIFF
--- a/src/nbstore/content.py
+++ b/src/nbstore/content.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-import atexit
 import base64
-from pathlib import Path
 
 
 def get_mime_content(data: dict[str, str]) -> tuple[str, str | bytes] | None:
@@ -25,51 +23,3 @@ def get_mime_content(data: dict[str, str]) -> tuple[str, str | bytes] | None:
             return mime, base64.b64decode(text)
 
     return None
-
-
-def get_suffix(mime: str) -> str:
-    """Get the suffix of a mime type.
-
-    Args:
-        mime (str): The mime type.
-
-    Returns:
-        str: The suffix of the mime type.
-    """
-    return "." + mime.split("/")[1]
-
-
-def create_image_file(
-    data: dict[str, str],
-    filename: Path | str,
-    *,
-    delete: bool = False,
-) -> Path | None:
-    """Create an image file from the data of a notebook cell.
-
-    Args:
-        data (dict[str, str]): The data of a notebook cell.
-        filename (Path | str): The filename of the image file.
-        delete (bool): Whether to delete the image file when the program exits.
-
-    Returns:
-        Path | None: The path to the image file.
-    """
-    decoded = get_mime_content(data)
-
-    if decoded is None:
-        return None
-
-    mime, content = decoded
-    suffix = get_suffix(mime)
-    file = Path(filename).with_suffix(suffix)
-
-    if isinstance(content, str):
-        file.write_text(content)
-    else:
-        file.write_bytes(content)
-
-    if delete:
-        atexit.register(lambda: file.unlink(missing_ok=True))
-
-    return file

--- a/src/nbstore/store.py
+++ b/src/nbstore/store.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any
 
 import nbformat
 
-from .content import create_image_file, get_mime_content
+from .content import get_mime_content
 
 if TYPE_CHECKING:
     from nbformat import NotebookNode
@@ -114,17 +114,6 @@ class Store:
     ) -> tuple[str, str | bytes] | None:
         data = self.get_data(url, identifier)
         return get_mime_content(data)
-
-    def create_image_file(
-        self,
-        url: str,
-        identifier: str,
-        filename: Path | str,
-        *,
-        delete: bool = False,
-    ) -> Path | None:
-        data = self.get_data(url, identifier)
-        return create_image_file(data, filename, delete=delete)
 
 
 def get_cell(nb: NotebookNode, identifier: str) -> dict[str, Any]:

--- a/tests/store/matplotlib/test_pdf.py
+++ b/tests/store/matplotlib/test_pdf.py
@@ -46,10 +46,3 @@ def test_data(store: Store):
     assert "text/plain" in data
     assert "image/png" in data
     assert data["application/pdf"].startswith("JVBE")
-
-
-def test_image(store: Store):
-    file = store.create_image_file("pdf.ipynb", "fig:pdf", "a", delete=True)
-    assert file
-    assert file.exists()
-    assert file.name == "a.pdf"

--- a/tests/store/matplotlib/test_png.py
+++ b/tests/store/matplotlib/test_png.py
@@ -1,5 +1,4 @@
 import pytest
-from PIL import Image
 
 from nbstore.store import Store
 
@@ -47,19 +46,3 @@ def test_mime_content(store: Store):
     assert len(data) == 2
     assert data[0] == "image/png"
     assert isinstance(data[1], bytes)
-
-
-def test_image(store: Store):
-    file = store.create_image_file("png.ipynb", "fig:png", "a", delete=True)
-    assert file
-    assert file.exists()
-    assert file.name == "a.png"
-    image = Image.open(file)
-    assert image.format == "PNG"
-    assert image.size == (1136, 826)
-
-
-def test_image_none():
-    from nbstore.content import create_image_file
-
-    assert create_image_file({}, "a") is None


### PR DESCRIPTION
- Removed the create_image_file function from content.py and store.py as it is no longer needed.
- Updated tests to reflect the removal of image file creation functionality.
- Simplified the content handling in the store module.