### PR TITLE
Refactor TeXLive installation in CI workflow to use a single apt-get …

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,9 +32,10 @@ jobs:
       - name: Install TeXLive
         run: |
           sudo apt-get update
-          sudo apt-get install texlive-xetex texlive-luatex texlive-latex-recommended
-          sudo apt-get install texlive-latex-extra texlive-lang-japanese
-          sudo apt-get install libcairo2 poppler-utils
+          sudo apt-get install -y --no-install-recommends \
+            texlive-xetex texlive-luatex texlive-latex-recommended \
+            texlive-latex-extra texlive-lang-japanese \
+            libcairo2 poppler-utils
           lualatex --version
           pdffonts -v
       - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
…command with no-install-recommends option for improved efficiency