### PR TITLE
Add `exclude_attributes` parameter to `iter_parts` method in Element class

### DIFF
--- a/src/nbstore/markdown.py
+++ b/src/nbstore/markdown.py
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING, ClassVar, TypeGuard
 import nbformat
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
+    from collections.abc import Iterable, Iterator
     from typing import Self
 
     from nbformat import NotebookNode
@@ -283,6 +283,7 @@ class Element(Matcher):
         include_identifier: bool = False,
         include_classes: bool = True,
         include_attributes: bool = True,
+        exclude_attributes: Iterable[str] = (),
     ) -> Iterator[str]:
         """Iterate through the parts of the element's attributes.
 
@@ -290,6 +291,7 @@ class Element(Matcher):
             include_identifier (bool): Whether to include the identifier.
             include_classes (bool): Whether to include the classes.
             include_attributes (bool): Whether to include the attributes.
+            exclude_attributes (Iterable[str]): Attributes to exclude.
 
         Yields:
             str: The parts of the element's attributes.
@@ -301,7 +303,9 @@ class Element(Matcher):
             yield from self.classes
 
         if include_attributes:
-            yield from (f"{k}={_quote(v)}" for k, v in self.attributes.items())
+            for k, v in self.attributes.items():
+                if k not in exclude_attributes:
+                    yield f"{k}={_quote(v)}"
 
 
 @dataclass

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -168,6 +168,13 @@ def test_iter_parts():
     assert list(x.iter_parts(include_identifier=True)) == ["#id", "a", "b", 'k="v"']
 
 
+def test_iter_parts_exclude_attributes():
+    from nbstore.markdown import Element
+
+    x = Element("", "id", ["a", "b"], {"k": "v", "l": "w"})
+    assert list(x.iter_parts(exclude_attributes=["l"])) == ["a", "b", 'k="v"']
+
+
 @pytest.mark.parametrize(
     ("markdown", "expected"),
     [


### PR DESCRIPTION
- Updated the method to allow exclusion of specified attributes during iteration.
- Added a new test to verify the functionality of excluding attributes.